### PR TITLE
Fixing kardianos/osext import path

### DIFF
--- a/basher.go
+++ b/basher.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"syscall"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 )
 
 func exitStatus(err error) (int, error) {


### PR DESCRIPTION
Building master fails with:

imports bitbucket.org/kardianos/osext: code in directory /Users/notmyrealname/prj/go/src/bitbucket.org/kardianos/osext expects import "githu
b.com/kardianos/osext"

The kardianos/osext source is moved from bitbucket to github on 22. of febr
see: https://bitbucket.org/kardianos/osext/src/816c96ec6fef6a0cd72c9395d192c4bd0d918753/osext.go?at=default#cl-6
