### PR TITLE
pass signals to child

### DIFF
--- a/basher.go
+++ b/basher.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"sync"
 	"syscall"
@@ -232,10 +233,23 @@ func (c *Context) Run(command string, args []string) (int, error) {
 	for _, arg := range args {
 		argstring = argstring + " '" + arg + "'"
 	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals)
+
 	cmd := exec.Command(c.BashPath, "-c", command+argstring)
 	cmd.Env = []string{"BASH_ENV=" + envfile}
 	cmd.Stdin = c.Stdin
 	cmd.Stdout = c.Stdout
 	cmd.Stderr = c.Stderr
-	return exitStatus(cmd.Run())
+	cmd.Start()
+	go func() {
+		for sig := range signals {
+			cmd.Process.Signal(sig)
+			if cmd.ProcessState != nil && !cmd.ProcessState.Exited() {
+				cmd.Process.Signal(sig)
+			}
+		}
+	}()
+	return exitStatus(cmd.Wait())
 }


### PR DESCRIPTION
This is just a proof of concept that passes signals to the child process of `Run()`. My go chops are not very good so I'm sure some clean up will be needed. I can say that this does in fact pass the signal from `docker stop` to the child process. 

using herokuish with the example repo: https://github.com/michaelshobbs/node-js-sample

node code:

```
var express = require('express');
var app = express();

app.set('port', (process.env.PORT || 5000));
app.use(express.static(__dirname + '/public'));

app.get('/', function(request, response) {
  response.send('Hello World!');
});

process.on( "SIGINT", function() {
  console.log('CLOSING [SIGINT]');
  process.exit();
} );

process.on( "SIGTERM", function() {
  console.log('CLOSING [SIGTERM]');
  process.exit();
} );

app.listen(app.get('port'), function() {
  console.log("Node app is running at localhost:" + app.get('port'));
});
```

```
Node app is running at localhost:5000
CLOSING [SIGTERM]
```

refs: #7 gliderlabs/herokuish#64 gliderlabs/herokuish#65
