### PR TITLE
Fix BASH_ENV not sourced when stdin is a Unix socket

### DIFF
--- a/basher.go
+++ b/basher.go
@@ -282,7 +282,7 @@ func (c *Context) Run(command string, args []string) (int, error) {
 	signal.Notify(signals)
 	signal.Ignore(syscall.SIGURG)
 
-	cmd := exec.Command(c.BashPath, "-c", command+argstring)
+	cmd := exec.Command(c.BashPath, "-c", "source '"+envfile+"'; "+command+argstring)
 	cmd.Env = []string{"BASH_ENV=" + envfile}
 	cmd.Stdin = c.Stdin
 	cmd.Stdout = c.Stdout


### PR DESCRIPTION
## Summary

- Bash 5.x silently skips sourcing `BASH_ENV` when stdin (fd 0) is a Unix socket
- Since `NewContext` defaults `Stdin` to `os.Stdin`, this causes `command not found` (exit 127) whenever the calling process has a socket as stdin — common with process supervisors, systemd socket activation, and tools that communicate over Unix sockets
- The fix explicitly sources the envfile in the `-c` command string instead of relying solely on `BASH_ENV`

## Root Cause

Bash checks the file type of stdin during startup. When stdin is a socket (`S_ISSOCK`), bash skips sourcing `BASH_ENV` before executing the `-c` command. This same error can be reproduced with Python:

```python
import socket, subprocess
parent, child = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
env = {'BASH_ENV': '/tmp/test.sh'}  # contains: main() { echo hello; }
r = subprocess.run(['/bin/bash', '-c', 'main'], stdin=child, capture_output=True, env=env)
# r.returncode == 127, "main: command not found"
```

Replacing `stdin=child` with `stdin=subprocess.PIPE` makes it work.

## Fix

One-line change in `Run()`: instead of `bash -c "command"` relying on `BASH_ENV`, use `bash -c "source '$envfile'; command"`.

## Test

`TestRunWithSocketStdin` creates a Unix socketpair, passes one end as stdin to a go-basher context, and verifies `Run()` succeeds.

## Related Issues

- #45 — "Error out when the shell script to be executed cannot be written to disk" (same symptom, different attributed cause)
- dokku/dokku#5764 — "bash: line 1: main: command not found" in dokku plugin commands