### PR TITLE
fix: stop leaking signal-forwarding goroutines from Context.Run

### DIFF
--- a/basher.go
+++ b/basher.go
@@ -281,6 +281,7 @@ func (c *Context) Run(command string, args []string) (int, error) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals)
 	signal.Ignore(syscall.SIGURG)
+	defer signal.Stop(signals)
 
 	cmd := exec.Command(c.BashPath, "-c", "source '"+envfile+"'; "+command+argstring)
 	cmd.Env = []string{"BASH_ENV=" + envfile}
@@ -290,20 +291,21 @@ func (c *Context) Run(command string, args []string) (int, error) {
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}
-	errChan := make(chan error, 1)
+
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		for sig := range signals {
-			if sig != syscall.SIGCHLD {
-				err = cmd.Process.Signal(sig)
-				if err != nil {
-					errChan <- err
+		for {
+			select {
+			case sig := <-signals:
+				if sig != nil && sig != syscall.SIGCHLD {
+					_ = cmd.Process.Signal(sig)
 				}
+			case <-done:
+				return
 			}
 		}
 	}()
-	go func() {
-		errChan <- cmd.Wait()
-	}()
-	err = <-errChan
-	return exitStatus(err)
+
+	return exitStatus(cmd.Wait())
 }

--- a/basher_test.go
+++ b/basher_test.go
@@ -2,10 +2,13 @@ package basher
 
 import (
 	"bytes"
+	"io"
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 var bashpath = "/bin/bash"
@@ -173,6 +176,45 @@ func TestRunWithSocketStdin(t *testing.T) {
 	}
 	if stdout.String() != "hello\n" {
 		t.Fatal("unexpected stdout:", stdout.String())
+	}
+}
+
+func TestRunDoesNotLeakGoroutines(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("hello.sh", testLoader)
+	bash.Stdout = io.Discard
+
+	if _, err := bash.Run("main", []string{}); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime.GC()
+	baseline := runtime.NumGoroutine()
+
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		status, err := bash.Run("main", []string{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if status != 0 {
+			t.Fatalf("non-zero exit on iteration %d", i)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var current int
+	for {
+		runtime.GC()
+		current = runtime.NumGoroutine()
+		if current-baseline <= 5 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if delta := current - baseline; delta > 5 {
+		t.Fatalf("goroutine leak: baseline=%d after %d Run calls=%d (delta=%d)", baseline, iterations, current, delta)
 	}
 }
 


### PR DESCRIPTION
Closes #55.

Context.Run registered a channel with signal.Notify but never called signal.Stop or terminated the forwarding goroutine, so each invocation leaked one goroutine and one registered signal channel. The forwarding goroutine is now scoped to the call via a done channel and signal.Stop runs on return. cmd.Wait runs inline, removing both the data race on err and the path that could orphan the bash process if signal forwarding failed.