### PR TITLE
fix: surface I/O errors from buildEnvfile

### DIFF
--- a/basher.go
+++ b/basher.go
@@ -2,6 +2,7 @@
 package basher
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"log"
@@ -221,11 +222,38 @@ func (c *Context) buildEnvfile() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+	name := file.Name()
+
+	cleanup := func() {
+		file.Close()
+		os.Remove(name)
+	}
+
+	if err := c.writeEnvfile(file); err != nil {
+		cleanup()
+		return "", err
+	}
+	if err := file.Sync(); err != nil {
+		cleanup()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		os.Remove(name)
+		return "", err
+	}
+	return name, nil
+}
+
+// writeEnvfile writes the BASH_ENV contents for this Context to w. Writes go
+// through a bufio.Writer so that any short-write or underlying I/O error is
+// captured and surfaced from the final Flush, rather than being silently
+// dropped by individual Write calls.
+func (c *Context) writeEnvfile(w io.Writer) error {
+	bw := bufio.NewWriter(w)
 	// variables
-	file.Write([]byte("unset BASH_ENV\n")) // unset for future calls to bash
-	file.Write([]byte("export SELF=" + os.Args[0] + "\n"))
-	file.Write([]byte("export SELF_EXECUTABLE='" + c.SelfPath + "'\n"))
+	fmt.Fprint(bw, "unset BASH_ENV\n") // unset for future calls to bash
+	fmt.Fprintf(bw, "export SELF=%s\n", os.Args[0])
+	fmt.Fprintf(bw, "export SELF_EXECUTABLE='%s'\n", c.SelfPath)
 	for _, kvp := range c.vars {
 		pair := strings.SplitN(kvp, "=", 2)
 		if len(pair) != 2 || strings.TrimSpace(pair[0]) == "" {
@@ -233,25 +261,26 @@ func (c *Context) buildEnvfile() (string, error) {
 		}
 
 		if isBashFunc(pair[0], pair[1]) {
-			bash_function_name := strings.TrimPrefix(pair[0], "BASH_FUNC_")
-			bash_function_name = strings.TrimSuffix(bash_function_name, "%%")
-			file.Write([]byte(fmt.Sprintf("%s%s\n", bash_function_name, pair[1])))
-			file.Write([]byte(fmt.Sprintf("export -f %s\n", bash_function_name)))
+			bashFuncName := strings.TrimPrefix(pair[0], "BASH_FUNC_")
+			bashFuncName = strings.TrimSuffix(bashFuncName, "%%")
+			fmt.Fprintf(bw, "%s%s\n", bashFuncName, pair[1])
+			fmt.Fprintf(bw, "export -f %s\n", bashFuncName)
 			continue
 		}
 
-		file.Write([]byte("export " + strings.Replace(
-			strings.Replace(kvp, "'", "\\'", -1), "=", "=$'", 1) + "'\n"))
+		fmt.Fprintf(bw, "export %s'\n", strings.Replace(
+			strings.Replace(kvp, "'", "\\'", -1), "=", "=$'", 1))
 	}
 	// functions
 	for cmd := range c.funcs {
-		file.Write([]byte(cmd + "() { $SELF_EXECUTABLE ::: " + cmd + " \"$@\"; }\n"))
+		fmt.Fprintf(bw, "%s() { $SELF_EXECUTABLE ::: %s \"$@\"; }\n", cmd, cmd)
 	}
 	// scripts
 	for _, data := range c.scripts {
-		file.Write(append(data, '\n'))
+		bw.Write(data)
+		bw.WriteByte('\n')
 	}
-	return file.Name(), nil
+	return bw.Flush()
 }
 
 func isBashFunc(key string, value string) bool {

--- a/basher_test.go
+++ b/basher_test.go
@@ -218,6 +218,93 @@ func TestRunDoesNotLeakGoroutines(t *testing.T) {
 	}
 }
 
+type shortWriter struct {
+	remaining int
+	err       error
+}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if w.remaining <= 0 {
+		return 0, w.err
+	}
+	if len(p) <= w.remaining {
+		w.remaining -= len(p)
+		return len(p), nil
+	}
+	n := w.remaining
+	w.remaining = 0
+	return n, w.err
+}
+
+func TestWriteEnvfileContents(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.SelfPath = "/bin/echo"
+	bash.Source("hello.sh", testLoader)
+	bash.Export("FOOBAR", "baz")
+	bash.ExportFunc("myfunc", func([]string) {})
+	bash.vars = append(bash.vars, "BASH_FUNC_helper%%=() { echo hi; }")
+
+	var buf bytes.Buffer
+	if err := bash.writeEnvfile(&buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+
+	wants := []string{
+		"unset BASH_ENV\n",
+		"export SELF=",
+		"export SELF_EXECUTABLE='/bin/echo'\n",
+		"export FOOBAR=$'baz'\n",
+		"helper() { echo hi; }\n",
+		"export -f helper\n",
+		"myfunc() { $SELF_EXECUTABLE ::: myfunc \"$@\"; }\n",
+		`main() { echo "hello"; }` + "\n",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("envfile missing %q\nfull output:\n%s", w, out)
+		}
+	}
+}
+
+func TestWriteEnvfileWriteError(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("hello.sh", testLoader)
+	bash.Export("FOOBAR", "baz")
+
+	w := &shortWriter{remaining: 8, err: io.ErrShortWrite}
+	err := bash.writeEnvfile(w)
+	if err == nil {
+		t.Fatal("expected error from writeEnvfile when underlying writer fails")
+	}
+}
+
+func TestBuildEnvfileWritesAndClosesFile(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("hello.sh", testLoader)
+	bash.Export("FOOBAR", "baz")
+
+	name, err := bash.buildEnvfile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(name)
+
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Fatal("envfile is empty")
+	}
+	if !strings.Contains(string(data), "unset BASH_ENV\n") {
+		t.Fatalf("envfile missing sentinel; contents:\n%s", data)
+	}
+	if !strings.Contains(string(data), `main() { echo "hello"; }`) {
+		t.Fatalf("envfile missing sourced script; contents:\n%s", data)
+	}
+}
+
 func TestIsBashFunc(t *testing.T) {
 	if isBashFunc("", "") {
 		t.Fatal("empty string is not a bash func")


### PR DESCRIPTION
Closes #58.

Writes in `Context.buildEnvfile` previously discarded their error returns and the function never called `Sync` or checked `Close`. On a full disk the generated `BASH_ENV` file would be silently truncated, surfacing later as opaque "function not found" or unbound-variable errors from the sourced script. The contents are now produced through a `bufio.Writer` so any short-write or underlying error is captured, then `Sync` and `Close` are checked explicitly with the partial file removed on failure.