### PR TITLE
test: cover signal-forwarding data race regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         shell: bash
         run: |
           go get -d -t
-          go test -v
+          go test -race -v

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BASH_DIR=.bash
 BASH_STATIC_VERSION=5.1.008-1.2.2
 
 test:
-	go test -v
+	go test -race -v
 
 build:
 	go install

--- a/basher_test.go
+++ b/basher_test.go
@@ -18,6 +18,7 @@ var testScripts = map[string]string{
 	"cat.sh":    `main() { cat; }`,
 	"printf.sh": `main() { printf "arg: <%s>" "$@"; }`,
 	"foobar.sh": `main() { echo $FOOBAR; }`,
+	"sleep.sh":  `main() { sleep 0.2; }`,
 }
 
 func testLoader(name string) ([]byte, error) {
@@ -215,6 +216,39 @@ func TestRunDoesNotLeakGoroutines(t *testing.T) {
 
 	if delta := current - baseline; delta > 5 {
 		t.Fatalf("goroutine leak: baseline=%d after %d Run calls=%d (delta=%d)", baseline, iterations, current, delta)
+	}
+}
+
+func TestRunSignalForwardingNoRace(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("sleep.sh", testLoader)
+	bash.Stdout = io.Discard
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(2 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				_ = syscall.Kill(syscall.Getpid(), syscall.SIGWINCH)
+			}
+		}
+	}()
+
+	status, err := bash.Run("main", []string{})
+	close(stop)
+	<-done
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatalf("non-zero exit: %d", status)
 	}
 }
 


### PR DESCRIPTION
Closes #56.

The data race reported in #56 was already eliminated as a side effect of #59 (the fix for #55), which moved `cmd.Wait` back onto the calling goroutine and changed the signal-forwarding goroutine to discard the result of `cmd.Process.Signal`. There is no longer a shared `err` variable between the two goroutines, so `go test -race` is clean on the current branch.

What was missing was a regression test that actually drives the signal-forwarding path concurrently with `cmd.Wait`. `TestRunSignalForwardingNoRace` runs a bash command that sleeps for 200ms and ticks SIGWINCH at the test process every 2ms, producing roughly a hundred forwarded signals while `cmd.Wait` returns. SIGWINCH is the safest choice because both bash (non-interactive) and the test process default to ignoring it, and `Context.Run` does not filter it out the way it does SIGCHLD.

I confirmed the test fails with the expected `DATA RACE` report if `_ = cmd.Process.Signal(sig)` is reverted to write the outer `err`, then restored to the current code.

Both the Makefile `test` target and `.github/workflows/ci.yml` now run `go test -race -v` so the regression is exercised on every build rather than only when someone happens to pass `-race` locally.