### PR TITLE
fix: extract embedded bash asset atomically on first run

### DIFF
--- a/basher.go
+++ b/basher.go
@@ -9,13 +9,21 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/kardianos/osext"
 	"github.com/mitchellh/go-homedir"
 )
+
+// staleBashTmpAge is the minimum age before a leftover "bash.tmp.*" file is
+// treated as orphaned from a crashed extraction rather than in-flight from a
+// concurrent call. Extraction of the embedded bash asset completes in
+// milliseconds, so anything an hour old cannot belong to a live extractor.
+const staleBashTmpAge = time.Hour
 
 func exitStatus(err error) (int, error) {
 	if err != nil {
@@ -53,13 +61,10 @@ func Application(
 		log.Fatal(err, "1")
 	}
 
-	bashPath := bashDir + "/bash"
-	if _, err := os.Stat(bashPath); os.IsNotExist(err) {
-		err = RestoreAsset(bashDir, "bash")
-		if err != nil {
-			log.Fatal(err, "1")
-		}
+	if err := restoreBashAtomically(bashDir); err != nil {
+		log.Fatal(err, "1")
 	}
+	bashPath := filepath.Join(bashDir, "bash")
 
 	ApplicationWithPath(funcs, scripts, loader, copyEnv, bashPath)
 }
@@ -104,6 +109,95 @@ func ApplicationWithPath(
 		}
 	}
 	os.Exit(status)
+}
+
+// restoreBashAtomically extracts the embedded "bash" asset to dir/bash so
+// that concurrent first-run invocations cannot observe a partial file. It
+// writes the asset to a unique temp file in the same directory and renames it
+// into place; the rename is atomic on POSIX filesystems, so any visible
+// dir/bash is always byte-complete. If dir/bash already exists, no work is
+// done. After a successful extraction, stale "bash.tmp.*" files left behind
+// by previously crashed extractions are best-effort swept.
+func restoreBashAtomically(dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	finalPath := filepath.Join(dir, "bash")
+	if _, err := os.Stat(finalPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	data, err := Asset("bash")
+	if err != nil {
+		return err
+	}
+	info, err := AssetInfo("bash")
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, "bash.tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, info.Mode()); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, finalPath); err != nil {
+		return err
+	}
+	committed = true
+
+	sweepStaleBashTmp(dir, filepath.Base(tmpName), staleBashTmpAge)
+	return nil
+}
+
+// sweepStaleBashTmp removes "bash.tmp.*" entries in dir whose mtime is older
+// than maxAge, skipping skipName. It is best-effort: errors are swallowed
+// because the only consequence of failure is leftover bytes on disk.
+func sweepStaleBashTmp(dir, skipName string, maxAge time.Duration) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == skipName {
+			continue
+		}
+		if !strings.HasPrefix(name, "bash.tmp.") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if time.Since(info.ModTime()) >= maxAge {
+			os.Remove(filepath.Join(dir, name))
+		}
+	}
 }
 
 // A Context is an instance of a Bash interpreter and environment, including

--- a/basher_test.go
+++ b/basher_test.go
@@ -2,10 +2,13 @@ package basher
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -336,6 +339,153 @@ func TestBuildEnvfileWritesAndClosesFile(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `main() { echo "hello"; }`) {
 		t.Fatalf("envfile missing sourced script; contents:\n%s", data)
+	}
+}
+
+func TestRestoreBashAtomicallyFreshDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := restoreBashAtomically(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	bashPath := filepath.Join(dir, "bash")
+	got, err := os.ReadFile(bashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := Asset("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sha256.Sum256(got) != sha256.Sum256(want) {
+		t.Fatalf("extracted bash bytes differ from embedded asset (got %d bytes, want %d)", len(got), len(want))
+	}
+
+	info, err := os.Stat(bashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("extracted bash is not executable: mode=%v", info.Mode())
+	}
+}
+
+func TestRestoreBashAtomicallyNoOpWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	bashPath := filepath.Join(dir, "bash")
+	sentinel := []byte("sentinel-not-bash")
+	if err := os.WriteFile(bashPath, sentinel, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreBashAtomically(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(bashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, sentinel) {
+		t.Fatalf("existing bash file was overwritten; got %q want %q", got, sentinel)
+	}
+}
+
+func TestRestoreBashAtomicallyNoTempLeftover(t *testing.T) {
+	dir := t.TempDir()
+	if err := restoreBashAtomically(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "bash.tmp.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no bash.tmp.* leftovers, got %v", matches)
+	}
+}
+
+func TestRestoreBashAtomicallySweepsStaleTemp(t *testing.T) {
+	dir := t.TempDir()
+
+	stalePath := filepath.Join(dir, "bash.tmp.stale")
+	if err := os.WriteFile(stalePath, []byte("orphan"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(stalePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	freshPath := filepath.Join(dir, "bash.tmp.fresh")
+	if err := os.WriteFile(freshPath, []byte("inflight"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreBashAtomically(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("expected stale temp to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Fatalf("expected fresh temp to be left alone, got err=%v", err)
+	}
+}
+
+func TestRestoreBashAtomicallyConcurrent(t *testing.T) {
+	dir := t.TempDir()
+
+	const workers = 16
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- restoreBashAtomically(dir)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent restoreBashAtomically failed: %v", err)
+		}
+	}
+
+	bashPath := filepath.Join(dir, "bash")
+	got, err := os.ReadFile(bashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := Asset("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sha256.Sum256(got) != sha256.Sum256(want) {
+		t.Fatalf("torn write: extracted bash bytes differ from embedded asset (got %d bytes, want %d)", len(got), len(want))
+	}
+
+	info, err := os.Stat(bashPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("extracted bash is not executable: mode=%v", info.Mode())
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "bash.tmp.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no bash.tmp.* leftovers after concurrent run, got %v", matches)
 	}
 }
 


### PR DESCRIPTION
Two concurrent first-run invocations could both observe a missing `~/.basher/bash`, both call `RestoreAsset`, and both write the binary in place at the same time, letting a reader exec a half-written ELF or Mach-O. Extraction now writes to a unique temp file in the same directory and renames it into place, and best-effort sweeps stale `bash.tmp.*` orphans left by previously crashed extractions.

Closes #57.