### PR TITLE
feat: add context.Context support to Run and Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ main() {
 }
 ```
 
+## Cancellation with context
+
+`Context.RunContext` accepts a `context.Context` and is otherwise identical to `Run`. Cancelling the context terminates the underlying Bash process via `exec.CommandContext`, which sends `SIGKILL`.
+
+```Go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+status, err := bash.RunContext(ctx, "main", os.Args[1:])
+```
+
+`ApplicationContext` and `ApplicationWithPathContext` are context-aware variants of the `Application*` helpers that forward `ctx` into the Bash invocation.
+
 ## Using go-basher with go-bindata
 
 You can bundle your Bash scripts into your Go binary using [go-bindata](https://github.com/jteeuwen/go-bindata). First install go-bindata:

--- a/basher.go
+++ b/basher.go
@@ -3,6 +3,7 @@ package basher
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -56,6 +57,19 @@ func Application(
 	loader func(string) ([]byte, error),
 	copyEnv bool) {
 
+	ApplicationContext(context.Background(), funcs, scripts, loader, copyEnv)
+}
+
+// ApplicationContext is like Application but accepts a context.Context that is
+// forwarded to the underlying Bash invocation. Cancelling ctx kills the Bash
+// process via exec.CommandContext (SIGKILL).
+func ApplicationContext(
+	ctx context.Context,
+	funcs map[string]func([]string),
+	scripts []string,
+	loader func(string) ([]byte, error),
+	copyEnv bool) {
+
 	bashDir, err := homedir.Expand("~/.basher")
 	if err != nil {
 		log.Fatal(err, "1")
@@ -66,12 +80,26 @@ func Application(
 	}
 	bashPath := filepath.Join(bashDir, "bash")
 
-	ApplicationWithPath(funcs, scripts, loader, copyEnv, bashPath)
+	ApplicationWithPathContext(ctx, funcs, scripts, loader, copyEnv, bashPath)
 }
 
 // ApplicationWithPath functions as Application does while also
 // allowing the developer to modify the specified bashPath.
 func ApplicationWithPath(
+	funcs map[string]func([]string),
+	scripts []string,
+	loader func(string) ([]byte, error),
+	copyEnv bool,
+	bashPath string) {
+
+	ApplicationWithPathContext(context.Background(), funcs, scripts, loader, copyEnv, bashPath)
+}
+
+// ApplicationWithPathContext is like ApplicationWithPath but accepts a
+// context.Context that is forwarded to the underlying Bash invocation.
+// Cancelling ctx kills the Bash process via exec.CommandContext (SIGKILL).
+func ApplicationWithPathContext(
+	ctx context.Context,
 	funcs map[string]func([]string),
 	scripts []string,
 	loader func(string) ([]byte, error),
@@ -97,7 +125,7 @@ func ApplicationWithPath(
 	if copyEnv {
 		bash.CopyEnv()
 	}
-	status, err := bash.Run("main", os.Args[1:])
+	status, err := bash.RunContext(ctx, "main", os.Args[1:])
 	if err != nil {
 		// the string message for ExitError shouldn't be logged
 		// as it is just `exit status $CODE`, which is redundant
@@ -387,6 +415,14 @@ func isBashFunc(key string, value string) bool {
 // default is attached to the calling process I/O. You can change this by setting
 // the Stdout, Stderr, Stdin variables of the Context.
 func (c *Context) Run(command string, args []string) (int, error) {
+	return c.RunContext(context.Background(), command, args)
+}
+
+// RunContext is like Run but uses exec.CommandContext under the hood, so
+// cancelling ctx terminates the Bash process. Per exec.CommandContext, the
+// child receives SIGKILL when ctx is cancelled. Parent-process signals are
+// still forwarded to Bash for the lifetime of the call regardless of ctx.
+func (c *Context) RunContext(ctx context.Context, command string, args []string) (int, error) {
 	c.Lock()
 	defer c.Unlock()
 	envfile, err := c.buildEnvfile()
@@ -406,7 +442,7 @@ func (c *Context) Run(command string, args []string) (int, error) {
 	signal.Ignore(syscall.SIGURG)
 	defer signal.Stop(signals)
 
-	cmd := exec.Command(c.BashPath, "-c", "source '"+envfile+"'; "+command+argstring)
+	cmd := exec.CommandContext(ctx, c.BashPath, "-c", "source '"+envfile+"'; "+command+argstring)
 	cmd.Env = []string{"BASH_ENV=" + envfile}
 	cmd.Stdin = c.Stdin
 	cmd.Stdout = c.Stdout

--- a/basher_test.go
+++ b/basher_test.go
@@ -2,6 +2,7 @@ package basher
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"io"
 	"os"
@@ -486,6 +487,89 @@ func TestRestoreBashAtomicallyConcurrent(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected no bash.tmp.* leftovers after concurrent run, got %v", matches)
+	}
+}
+
+func TestRunContextBackground(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("hello.sh", testLoader)
+
+	var stdout bytes.Buffer
+	bash.Stdout = &stdout
+	status, err := bash.RunContext(context.Background(), "main", []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatal("non-zero exit")
+	}
+	if stdout.String() != "hello\n" {
+		t.Fatal("unexpected stdout:", stdout.String())
+	}
+}
+
+func TestRunContextAlreadyCanceled(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("hello.sh", testLoader)
+	bash.Stdout = io.Discard
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status, err := bash.RunContext(ctx, "main", []string{})
+	if err == nil {
+		t.Fatalf("expected error from canceled context, got nil (status=%d)", status)
+	}
+}
+
+func TestRunContextCanceledDuringRun(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("sleep.sh", testLoader)
+	bash.Stdout = io.Discard
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	defer cancel()
+
+	deadline := time.Now().Add(time.Second)
+	start := time.Now()
+	status, err := bash.RunContext(ctx, "main", []string{})
+	elapsed := time.Since(start)
+
+	if time.Now().After(deadline) {
+		t.Fatalf("RunContext did not return promptly after cancel; elapsed=%v", elapsed)
+	}
+	if err == nil {
+		t.Fatalf("expected error from canceled context, got nil (status=%d)", status)
+	}
+	if status == 0 {
+		t.Fatalf("expected non-zero exit status from killed bash, got 0")
+	}
+}
+
+func TestRunContextDeadline(t *testing.T) {
+	bash, _ := NewContext(bashpath, false)
+	bash.Source("sleep.sh", testLoader)
+	bash.Stdout = io.Discard
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	status, err := bash.RunContext(ctx, "main", []string{})
+	elapsed := time.Since(start)
+
+	if elapsed > time.Second {
+		t.Fatalf("RunContext did not honor deadline; elapsed=%v", elapsed)
+	}
+	if err == nil {
+		t.Fatalf("expected error from expired deadline, got nil (status=%d)", status)
+	}
+	if status == 0 {
+		t.Fatalf("expected non-zero exit status from killed bash, got 0")
 	}
 }
 


### PR DESCRIPTION
Closes #35.

Adds `Context.RunContext`, which mirrors `Run` but uses `exec.CommandContext` so callers can cancel or time-bound a Bash invocation. `Run` becomes a thin wrapper that passes `context.Background()`. `ApplicationContext` and `ApplicationWithPathContext` are new context-aware variants of the existing `Application*` helpers; the originals delegate to them with a background context. On cancellation Bash receives `SIGKILL` per `exec.CommandContext` semantics; the existing parent-to-child signal forwarding goroutine is preserved unchanged.